### PR TITLE
feat: automatically sort sponsors based on tier priority

### DIFF
--- a/src/components/SupportUsButton.tsx
+++ b/src/components/SupportUsButton.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { supportUsButtonProps } from "../types/index";
 import type { Theme } from "../types/index";
 import type { ButtonVariant } from "../types/index";
+import type { Tier } from "../types/index";
 
 // Function to get the appropriate classes based on the selected theme, used for styling different sections of the component according to the chosen theme
 function classAccordingToTheme(Theme: Theme): string {
@@ -70,6 +71,18 @@ function SupportUsButton({
   },
   buttonVariant = "AOSSIE",
 }: supportUsButtonProps): React.JSX.Element {
+  const sortedSponsors = sponsors ? [...sponsors].sort((a, b) => {
+    const tierPriority: Record<Tier, number> = {
+      Platinum: 1,
+      Gold: 2,
+      Silver: 3,
+      Bronze: 4,
+    };
+    const aTier = a.sponsorshipTier || 'Bronze';
+    const bTier = b.sponsorshipTier || 'Bronze';
+    return tierPriority[aTier] - tierPriority[bTier];
+  }) : [];
+
   return (
     // Container for the support us button, with dynamic classes based on the selected theme and custom class names
     <div
@@ -240,7 +253,7 @@ function SupportUsButton({
           ${Theme === "minimal" && "bg-gray-800/50"}
           ${Theme === "corporate" && "bg-blue-600/50"}`}
       >
-        {sponsors && sponsors.length > 0 && (
+        {sortedSponsors && sortedSponsors.length > 0 && (
           // List of sponsors with their logos and links, styled according to the selected theme and custom class names
           <div
             className={`${classNames.sponsors} ${classAccordingToTheme(Theme)}
@@ -275,7 +288,7 @@ function SupportUsButton({
 
             {/* Sponsor logos */}
             <div className="flex flex-row flex-wrap justify-center items-center gap-10 z-10">
-              {sponsors.map((sponsor, index) => (
+              {sortedSponsors.map((sponsor, index) => (
                 <a
                   href={sponsor.link}
                   key={index}


### PR DESCRIPTION
### Addressed Issues:

Fixes #11 

### Screenshots/Recordings:

N/A – This change introduces internal logic to automatically sort sponsors by their sponsorship tier before rendering. There are no visual UI changes.

### Additional Notes:

This PR introduces automatic sorting of sponsors based on their sponsorship tier priority.

Sponsors are now displayed in the following order:

Platinum → Gold → Silver → Bronze

This ensures that higher-tier sponsors receive appropriate visibility and maintains a consistent sponsorship hierarchy across implementations of the SupportUsButton component.

The sorting is implemented without mutating the original props array to maintain React best practices and TypeScript type safety.

## Checklist

* [x] My code follows the project's code style and conventions
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or errors
* [x] I have joined the Discord server and I will share a link to this PR with the project maintainers there
* [x] I have read the Contributing Guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sponsors are now displayed in organized order by sponsorship tier (Platinum, Gold, Silver, Bronze).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->