### PR TITLE
feat: add optional copy sponsor link button

### DIFF
--- a/src/components/SupportUsButton.tsx
+++ b/src/components/SupportUsButton.tsx
@@ -70,7 +70,20 @@ function SupportUsButton({
     ctaSection: "",
   },
   buttonVariant = "AOSSIE",
+  showCopyLinkButton = false,
 }: supportUsButtonProps): React.JSX.Element {
+  const [copiedLink, setCopiedLink] = React.useState<string | null>(null);
+
+  const handleCopyLink = (e: React.MouseEvent, link: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    navigator.clipboard.writeText(link);
+    setCopiedLink(link);
+    setTimeout(() => {
+      setCopiedLink(null);
+    }, 2000);
+  };
+
   const sortedSponsors = sponsors ? [...sponsors].sort((a, b) => {
     const tierPriority: Record<Tier, number> = {
       Platinum: 1,
@@ -403,7 +416,23 @@ function SupportUsButton({
                     )}
 
                     <div className="w-full">
-                      <h3 className={`font-bold text-2xl`}>{sponsor.name}</h3>
+                      <div className="flex justify-between items-start gap-2">
+                        <h3 className={`font-bold text-2xl`}>{sponsor.name}</h3>
+                        {showCopyLinkButton && sponsor.link && (
+                          <button
+                            onClick={(e) => handleCopyLink(e, sponsor.link!)}
+                            className="p-1.5 rounded-lg transition-colors hover:bg-black/10 dark:hover:bg-white/10"
+                            title="Copy link"
+                            aria-label="Copy sponsor link"
+                          >
+                            {copiedLink === sponsor.link ? (
+                              <span className="text-green-500 font-semibold text-sm mr-1">Copied!</span>
+                            ) : (
+                              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>
+                            )}
+                          </button>
+                        )}
+                      </div>
                       {sponsor.sponsorshipTier && (
                         <span className="flex text-[16px] p-2 rounded-xl items-center mt-3.5 font-semibold bg-[#d0f2eb] text-black w-fit">
                           {sponsor.sponsorshipTier}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -152,4 +152,7 @@ export interface supportUsButtonProps {
 
   // Optional button variant for styling the call-to-action buttons
   buttonVariant?: ButtonVariant;
+
+  // Optional flag to show a copy link button on sponsor cards
+  showCopyLinkButton?: boolean;
 }


### PR DESCRIPTION
### Addressed Issues:

Fixes #15 

### Screenshots/Recordings:

N/A – This feature adds an optional copy sponsor link button for sponsor cards. Since the change introduces a small interactive feature, visual UI structure remains mostly unchanged.

### Additional Notes:

This PR introduces an optional **Copy Sponsor Link** button for sponsor cards.

When enabled, users can easily copy the sponsor's URL to their clipboard using the browser Clipboard API.

Key points:

* Adds a new optional prop: `showCopyLinkButton`
* Uses `navigator.clipboard.writeText()` to copy the sponsor URL
* Improves usability by allowing quick sharing of sponsor links
* Maintains TypeScript compatibility and does not modify existing functionality

This enhancement improves user interaction and makes it easier to share sponsor links.

## Checklist

* [x] My code follows the project's code style and conventions
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or errors
* [x] I have joined the Discord server and I will share a link to this PR with the project maintainers there
* [x] I have read the Contributing Guidelines